### PR TITLE
Update help link in Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: 🆘 I need Help
-    url: https://github.com/octokit/rest.js/discussions
+    url: https://github.com/octokit/octokit.js/discussions
     about: Got a question? An idea? Feedback? Start here.


### PR DESCRIPTION
Seems like the link in the Issue Template is outdated.

The original link (https://github.com/octokit/rest.js/discussions) no longer works, so I looked at the config from the `rest.js` project, which uses https://github.com/octokit/octokit.js/discussions and updated the template of this repository accordingly:
https://github.com/octokit/rest.js/blob/master/.github/ISSUE_TEMPLATE/config.yml

## Changes
- Updates `url` of ISSUE_TEMPLATE contact link