### PR TITLE
docs: replace references to Skypack CDN with esm.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ Browsers
 
 </th><td width=100%>
 
-Load `@octokit/auth-oauth-user` directly from [cdn.skypack.dev](https://cdn.skypack.dev)
+Load `@octokit/auth-oauth-user` directly from [esm.sh](https://esm.sh)
 
 ```html
 <script type="module">
-  import { createOAuthUserAuth } from "https://cdn.skypack.dev/@octokit/auth-oauth-user";
+  import { createOAuthUserAuth } from "https://esm.sh/@octokit/auth-oauth-user";
 </script>
 ```
 


### PR DESCRIPTION
The Skypack CDN is no longer maintained, so we should remove references to it.