### PR TITLE
Ensure onTokenCreated is fired for both explicit and time based refresh.

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -66,6 +66,9 @@ export async function auth(
         type: "token",
         ...authentication,
       };
+      await state.onTokenCreated?.(state.authentication, {
+        type: "refresh",
+      });
     }
   }
 
@@ -80,10 +83,6 @@ export async function auth(
     if (!currentAuthentication.hasOwnProperty("expiresAt")) {
       throw new Error("[@octokit/auth-oauth-user] Refresh token missing");
     }
-
-    await state.onTokenCreated?.(state.authentication, {
-      type: options.type,
-    });
   }
 
   // check or reset token

--- a/test/standalone.test.ts
+++ b/test/standalone.test.ts
@@ -350,6 +350,8 @@ test("Caches authentication for successive calls", async () => {
 
 describe("refreshing tokens", () => {
   test("auto-refreshing for expiring tokens", async () => {
+    const onTokenCreated = vi.fn();
+
     const mock = fetchMock.createInstance().postOnce(
       ({ url, options }) => {
         expect(url).toEqual("https://github.com/login/oauth/access_token");
@@ -391,6 +393,7 @@ describe("refreshing tokens", () => {
       expiresAt: "1970-01-01T08:00:00.000Z",
       refreshToken: "r1.token123",
       refreshTokenExpiresAt: "1970-07-04T00:00:00.000Z",
+      onTokenCreated,
 
       // pass request mock for testing
       request: request.defaults({
@@ -416,12 +419,14 @@ describe("refreshing tokens", () => {
       expiresAt: "1970-01-01T08:00:00.000Z",
       refreshToken: "r1.token123",
       refreshTokenExpiresAt: "1970-07-04T00:00:00.000Z",
+      onTokenCreated,
     });
 
     // not yet expired
     MockDate.set("1970-01-01T05:00:00.000Z");
     const authentication2 = await auth();
     expect(authentication2).toEqual(authentication1);
+    expect(onTokenCreated).toHaveBeenCalledTimes(0);
 
     // expired
     MockDate.set("1970-01-01T10:00:00.000Z");
@@ -437,6 +442,10 @@ describe("refreshing tokens", () => {
       expiresAt: "1970-01-01T18:00:00.000Z",
       refreshToken: "r1.token456",
       refreshTokenExpiresAt: "1970-07-04T10:00:00.000Z",
+    });
+    expect(onTokenCreated).toHaveBeenCalledTimes(1);
+    expect(onTokenCreated).toHaveBeenNthCalledWith(1, authentication3, {
+      type: "refresh",
     });
 
     MockDate.reset();


### PR DESCRIPTION
Resolves #373

----

### Before the change?

* Tokens being refreshed because of a date expiry did not call the callback

### After the change?

* Tokens being explicitly or implicitly refreshed call the callback

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

It's hard to say, it will result in a new event when tokens auto expire, however this in my opinion was a bug.
