### PR TITLE
fix(auth): fire onTokenCreated when a token is auto-refreshed on expiry

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -66,6 +66,13 @@ export async function auth(
         type: "token",
         ...authentication,
       };
+      // Notify subscribers of the refreshed token. Previously this only fired
+      // for an explicit `auth({ type: 'refresh' })` call, so callers that
+      // wanted to persist refreshed tokens silently lost the auto-refresh-on-
+      // expiry case (#373).
+      await state.onTokenCreated?.(state.authentication, {
+        type: options.type ?? "refresh",
+      });
     }
   }
 
@@ -80,10 +87,6 @@ export async function auth(
     if (!currentAuthentication.hasOwnProperty("expiresAt")) {
       throw new Error("[@octokit/auth-oauth-user] Refresh token missing");
     }
-
-    await state.onTokenCreated?.(state.authentication, {
-      type: options.type,
-    });
   }
 
   // check or reset token

--- a/test/standalone.test.ts
+++ b/test/standalone.test.ts
@@ -442,6 +442,77 @@ describe("refreshing tokens", () => {
     MockDate.reset();
   });
 
+  // Regression for #373. Before the fix, `onTokenCreated` only fired on an
+  // explicit `auth({ type: 'refresh' })` call. Tokens that auto-refreshed
+  // because they had expired did not fire the callback, so consumers who
+  // needed to persist refreshed tokens silently missed the auto-refresh
+  // case and lost auth state on subsequent requests.
+  test('auto-refresh on expiry fires "onTokenCreated()" callback', async () => {
+    const mock = fetchMock
+      .createInstance()
+      .postOnce(
+        ({ url }) => url === "https://github.com/login/oauth/access_token",
+        {
+          body: {
+            access_token: "token456",
+            scope: "",
+            token_type: "bearer",
+            expires_in: 28800,
+            refresh_token: "r1.token456",
+            refresh_token_expires_in: 15897600,
+          },
+          headers: {
+            date: "Thu, 1 Jan 1970 10:00:00 GMT",
+          },
+        },
+      );
+
+    const expectedAuthenticationObject = {
+      type: "token",
+      tokenType: "oauth",
+      clientType: "github-app",
+      clientId: "lv1.1234567890abcdef",
+      clientSecret: "secret",
+      token: "token456",
+      expiresAt: "1970-01-01T18:00:00.000Z",
+      refreshToken: "r1.token456",
+      refreshTokenExpiresAt: "1970-07-04T10:00:00.000Z",
+    };
+
+    const onTokenCreated = vi.fn();
+    const auth = createOAuthUserAuth({
+      clientType: "github-app",
+      clientId: "lv1.1234567890abcdef",
+      clientSecret: "secret",
+      token: "token123",
+      expiresAt: "1970-01-01T08:00:00.000Z",
+      refreshToken: "r1.token123",
+      refreshTokenExpiresAt: "1970-07-04T00:00:00.000Z",
+      onTokenCreated,
+      request: request.defaults({
+        headers: { "user-agent": "test" },
+        request: { fetch: mock.fetchHandler },
+      }),
+    });
+
+    // The first call uses a still-valid token: no refresh, no callback.
+    MockDate.set("1970-01-01T05:00:00.000Z");
+    await auth();
+    expect(onTokenCreated).not.toHaveBeenCalled();
+
+    // The second call lands after the token's expiresAt: auto-refresh runs
+    // and the callback must fire so subscribers can persist the new token.
+    MockDate.set("1970-01-01T10:00:00.000Z");
+    const refreshed = await auth();
+    expect(refreshed).toEqual(expectedAuthenticationObject);
+    expect(onTokenCreated).toHaveBeenCalledTimes(1);
+    expect(onTokenCreated).toHaveBeenCalledWith(expectedAuthenticationObject, {
+      type: "refresh",
+    });
+
+    MockDate.reset();
+  });
+
   test('auth({ type: "refresh" })', async () => {
     const mock = fetchMock.createInstance().postOnce(
       ({ url, options }) => {


### PR DESCRIPTION
## Summary

`onTokenCreated` was only invoked on an explicit `auth({ type: 'refresh' })` call. When the same token was refreshed automatically because its `expiresAt` had passed (the common case in long-lived processes), the new token was stored on `state.authentication` but the callback never fired — so consumers persisting refreshed tokens silently lost auth state on subsequent requests (#373).

[`src/auth.ts:51-87`](src/auth.ts#L51-L87) on `main`:

```ts
// (auto) refresh for user-to-server tokens
if ('expiresAt' in currentAuthentication) {
  if (options.type === 'refresh' || new Date(currentAuthentication.expiresAt) < new Date()) {
    const { authentication } = await refreshToken({ ... });
    state.authentication = { ... };
    // ← callback never fires here
  }
}

// throw error for invalid refresh call
if (options.type === 'refresh') {
  // ...validation throws...
  await state.onTokenCreated?.(state.authentication, { type: options.type });  // only here
}
```

## Fix

Move the `onTokenCreated` invocation inside the refresh block so both the auto-refresh-on-expiry and the explicit-refresh paths trigger it. Pass `type: 'refresh'` (falling back from `options.type ?? 'refresh'`) so subscribers see the same payload shape they got from an explicit refresh — the auto-refresh case otherwise reaches the callback with `options.type === undefined`, which is harder to react to.

The validation branch for `options.type === 'refresh'` only triggers when the auto-refresh block was skipped (`oauth-app` clientType, or non-expiring authentication), so the callback never fires for the error paths.

## Tests

Added `auto-refresh on expiry fires \"onTokenCreated()\" callback` in [`test/standalone.test.ts`](test/standalone.test.ts):

- Set the date before `expiresAt` and call `auth()` → no refresh, callback **not** called.
- Move the date past `expiresAt` and call `auth()` → auto-refresh runs, callback fires **once** with the new authentication and `{ type: 'refresh' }`.

Verified this fails on `main` and passes after the change. The existing `auth({ type: \"refresh\" }) with \"onTokenCreated()\" option` test (which covers the explicit-refresh path) still passes — the callback fires once from the refresh block, the validation block no longer fires it.

## Test plan

- [x] `npx vitest run test/standalone.test.ts` — 24/24 pass (23 existing + 1 new)
- [x] `npx prettier --check 'src/**/*' 'test/**/*'` — clean
- [x] Verified the new test fails on `main` by reverting only the production change

Closes #373